### PR TITLE
Adding Guava and JAX-RS To the JDK 11 Tests and JLink Build

### DIFF
--- a/JLink/pom.xml
+++ b/JLink/pom.xml
@@ -13,7 +13,7 @@
 	
 	<properties>
 		<enforcer.skip>true</enforcer.skip>
-        <guicedee.version>0.70.0.1-rc2</guicedee.version>
+        <guicedee.version>0.70.0.6</guicedee.version>
 	</properties>
 
     <dependencies>
@@ -103,6 +103,26 @@
             <artifactId>woodstox-core</artifactId>
             <version>6.0.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+            <version>2.10.1</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>guava</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.guicedee.services</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guicedee.version}</version>
+        </dependency>
+
+
+
 
 
 

--- a/jdk11-tests/pom.xml
+++ b/jdk11-tests/pom.xml
@@ -16,6 +16,13 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
+
+        <!-- Apache CXF + Jersey JAX-RS Implementation-->
+        <dependency>
+            <groupId>com.guicedee.servlets</groupId>
+            <artifactId>guiced-rest-services</artifactId>
+            <version>${guicedee.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jdk11-tests/src/main/java/com/fasterxml/jackson/compat11/AllManualTests.java
+++ b/jdk11-tests/src/main/java/com/fasterxml/jackson/compat11/AllManualTests.java
@@ -14,7 +14,7 @@ public class AllManualTests
 
         // other modules
         ManualJAXBTest.main(args);
-        
+
         System.out.println("... All tests complete!");
     }
 }

--- a/jdk11-tests/src/main/java/com/fasterxml/jackson/compat11/jaxrs/HelloResource.java
+++ b/jdk11-tests/src/main/java/com/fasterxml/jackson/compat11/jaxrs/HelloResource.java
@@ -1,0 +1,19 @@
+package com.fasterxml.jackson.compat11.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+@Path("hello")
+@Produces("application/json")
+public class HelloResource
+{
+	@GET
+	@Path("helloObject/{name}")
+	public ReturnableObject helloObject(@PathParam("name") final String name)
+	{
+		return new ReturnableObject().setName(name);
+	}
+
+}

--- a/jdk11-tests/src/main/java/com/fasterxml/jackson/compat11/jaxrs/ReturnableObject.java
+++ b/jdk11-tests/src/main/java/com/fasterxml/jackson/compat11/jaxrs/ReturnableObject.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.compat11.jaxrs;
+
+public class ReturnableObject
+{
+	private String name;
+	public ReturnableObject()
+	{
+	}
+
+	public String getName()
+	{
+		return name;
+	}
+
+	public ReturnableObject setName(String name)
+	{
+		this.name = name;
+		return this;
+	}
+}

--- a/jdk11-tests/src/main/java/module-info.java
+++ b/jdk11-tests/src/main/java/module-info.java
@@ -1,3 +1,4 @@
+
 module jackson.compat11test {
     // we get annotations, streaming, too, via databind:
     requires transitive com.fasterxml.jackson.annotation;
@@ -16,12 +17,15 @@ module jackson.compat11test {
 	requires com.fasterxml.jackson.dataformat.yaml;
 	requires com.fasterxml.jackson.dataformat.protobuf;
 	requires com.fasterxml.jackson.dataformat.smile;
+	requires com.fasterxml.jackson.datatype.guava;
 	//requires com.fasterxml.jackson.dataformat.ion;
 	requires com.fasterxml.jackson.datatype.joda;
+	requires com.fasterxml.jackson.jaxrs.json;
 
 	requires static joda.time;
 
 	requires com.fasterxml.jackson.module.afterburner;
+	requires com.google.common;
 
 	requires java.xml.bind;
    // and then some base modules as well
@@ -32,13 +36,18 @@ module jackson.compat11test {
     requires com.ctc.wstx;
 
     requires com.google.guice;
-    requires com.google.common;
 
     //Todo Needs to go static guava, static com.google.common
 	//requires com.fasterxml.jackson.datatype.guava;
 	requires com.fasterxml.jackson.module.mrbean;
+	requires java.net.http;
+	requires java.logging;
+	requires com.guicedee.guicedservlets.rest;
+	requires com.guicedee.guicedservlets.undertow;
+	requires undertow.core;
+	requires java.ws.rs;
 
 	// and finally open up types for tests
     exports com.fasterxml.jackson.compat11.testutil;
-    opens com.fasterxml.jackson.compat11.testutil;
+    opens com.fasterxml.jackson.compat11.testutil to com.fasterxml.jackson.databind;
 }

--- a/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/dt/GuavaTest.java
+++ b/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/dt/GuavaTest.java
@@ -18,6 +18,7 @@ public class GuavaTest extends BaseTest
 	@Test
     public void testImmutableSortedSet() throws Exception
     {
+	    //TODO how does this work
         ImmutableSortedSet<Integer> set = MAPPER.readValue("[5,1,2]",
                 new TypeReference<ImmutableSortedSet<Integer>>() { });
         assertEquals(3, set.size());

--- a/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/misc/RestModuleTest.java
+++ b/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/misc/RestModuleTest.java
@@ -1,0 +1,52 @@
+package com.fasterxml.jackson.compat11.test.misc;
+
+
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import com.guicedee.guicedservlets.rest.RESTContext;
+import com.guicedee.guicedservlets.undertow.GuicedUndertow;
+import com.guicedee.logger.LogFactory;
+import io.undertow.Undertow;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.logging.Level;
+
+public class RestModuleTest
+{
+
+	public static void main(String[] args) throws Exception
+	{
+		LogFactory.configureConsoleSingleLineOutput(Level.FINE);
+		new RestModuleTest().testConfigureServlets();
+	}
+
+	@Test
+	public void testConfigureServlets() throws Exception
+	{
+		//Manually adding them in so it doesn't pick up oauth etc, clean jackson provider test
+		RESTContext.getProviders()
+		           .add(JacksonJaxbJsonProvider.class.getCanonicalName());
+		Undertow undertow = GuicedUndertow.boot("0.0.0.0", 6003);
+		//Do stuff
+		HttpClient client = HttpClient.newBuilder()
+		                              .connectTimeout(Duration.of(5, ChronoUnit.SECONDS))
+		                              .build();
+		HttpResponse<String> response = client.send(HttpRequest.newBuilder()
+		                                                       .GET()
+		                                                       .uri(new URI("http://localhost:6003/rest/hello/helloObject/world"))
+		                                                       .build(),
+		                                            HttpResponse.BodyHandlers.ofString());
+		System.out.println("Rest Response : " + response.body());
+		if (response.statusCode() / 100 != 2 || !response.body()
+		                                                 .equals("{\"name\":\"world\"}"))
+		{
+			throw new Exception("Didn't manage to make a rest servlet");
+		}
+		undertow.stop();
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.10.0-SNAPSHOT</version>
+        <version>2.10.1</version>
     </parent>
     <groupId>com.fasterxml.jackson.util</groupId>
     <artifactId>jackson-jdk11-compat-test</artifactId>
@@ -35,7 +35,7 @@
         <version.plugin.surefire>3.0.0-M3</version.plugin.surefire>
         <enforcer.skip>true</enforcer.skip>
 
-        <guicedee.version>0.70.0.1-rc2</guicedee.version>
+        <guicedee.version>0.70.0.6</guicedee.version>
     </properties>
 
     <modules>
@@ -138,11 +138,16 @@
               <optional>true</optional>
         </dependency>
 
-        <!--<dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
-            <optional>true</optional>
-        </dependency>-->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Use JDK 11 Compatible Libraries-->
         <dependency>
@@ -169,6 +174,23 @@
             <groupId>com.guicedee.services</groupId>
             <artifactId>guice</artifactId>
             <version>${guicedee.version}</version>
+        </dependency>
+
+        <!-- Access the github build -->
+        <!-- Waiting on 2.10.1.1 for jaxrs and base module fix -->
+        <!-- TODO put back to jackson libraries after 2.10.1.1 -->
+        <dependency>
+            <groupId>com.guicedee.services</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>${guicedee.version}</version>
+            <type>jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>com.guicedee.services</groupId>
+            <artifactId>jackson-jaxrs-base</artifactId>
+            <version>${guicedee.version}</version>
+            <type>jar</type>
         </dependency>
 
         <!-- and good old junit too -->
@@ -203,7 +225,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-		
     </repositories>
 
     <build>


### PR DESCRIPTION
Leaves one failing test for Guava on immutable set