### PR TITLE
Jakarta - 2.12rc2 - Verified and Tested - Finished

### DIFF
--- a/JLink/pom.xml
+++ b/JLink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.fasterxml.jackson.util</groupId>
         <artifactId>jackson-jdk11-compat-test</artifactId>
-        <version>2.12.0-rc2-SNAPSHOT</version>
+        <version>2.12.0-rc2</version>
     </parent>
 
     <artifactId>jackson-jlink</artifactId>

--- a/jdk11-tests/pom.xml
+++ b/jdk11-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.fasterxml.jackson.util</groupId>
         <artifactId>jackson-jdk11-compat-test</artifactId>
-        <version>2.12.0-rc2-SNAPSHOT</version>
+        <version>2.12.0-rc2</version>
     </parent>
 
     <artifactId>jdk11-tests</artifactId>
@@ -22,7 +22,7 @@
             <artifactId>jackson-dataformat-avro</artifactId>
         </dependency>
 
-        <!-- JAXB sort of ubiquitous -->
+        <!-- Jakarta Classified Artifacts for the versions -->
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
@@ -43,6 +43,48 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jaxrs</artifactId>
+            <classifier>jakarta</classifier>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-base</artifactId>
+            <classifier>jakarta</classifier>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <classifier>jakarta</classifier>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Jakarta Artefacts end here -->
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -110,32 +152,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jaxrs</artifactId>
-            <classifier>jakarta</classifier>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-base</artifactId>
-            <classifier>jakarta</classifier>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- GedMarc 2020/11/15 : module-named guice, test case artifacts for jax-rs in jakarta  -->
         <dependency>
             <groupId>com.guicedee.services</groupId>
@@ -156,6 +172,10 @@
                 <exclusion>
                     <groupId>com.guicedee.services</groupId>
                     <artifactId>jackson-datatype-jaxrs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.guicedee.services</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -178,6 +198,10 @@
                 <exclusion>
                     <groupId>com.guicedee.services</groupId>
                     <artifactId>jackson-datatype-jaxrs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.guicedee.services</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/jdk11-tests/pom.xml
+++ b/jdk11-tests/pom.xml
@@ -140,14 +140,14 @@
         <dependency>
             <groupId>com.guicedee.services</groupId>
             <artifactId>guice</artifactId>
-            <version>1.1.0.1</version>
+            <version>${guicedee.version}</version>
         </dependency>
 
         <!-- GedMarc 2020/11/15 - just until they release module-info versions -->
         <dependency>
             <groupId>com.guicedee.services</groupId>
             <artifactId>org.apache.cxf</artifactId>
-            <version>1.1.0.1</version>
+            <version>${guicedee.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.guicedee.services</groupId>
@@ -163,13 +163,13 @@
         <dependency>
             <groupId>com.guicedee.services</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.1.0.1</version>
+            <version>${guicedee.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.guicedee.servlets</groupId>
             <artifactId>guiced-rest-services</artifactId>
-            <version>1.1.0.1</version>
+            <version>${guicedee.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.guicedee.services</groupId>
@@ -185,13 +185,19 @@
         <dependency>
             <groupId>com.guicedee.services</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>1.1.0.1</version>
+            <version>${guicedee.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.guicedee.services</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>1.1.0.1</version>
+            <version>${guicedee.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.guicedee.services</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${guicedee.version}</version>
         </dependency>
 
     </dependencies>

--- a/jdk11-tests/src/main/java/module-info.java
+++ b/jdk11-tests/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module jackson.compat11test {
 
     //requires compatible depedencies
 
-
+	requires jakarta.validation;
 
 	requires com.fasterxml.jackson.datatype.guava;
 	//requires com.fasterxml.jackson.dataformat.ion;
@@ -40,6 +40,8 @@ module jackson.compat11test {
    // and then some base modules as well
 
     requires com.fasterxml.jackson.module.jaxb;
+    //solve for org.apache.cxf.validation.BeanValidationProvider - Bean Validation provider can not be found, no validation will be performed
+    requires org.hibernate.validator;
 
     requires com.ctc.wstx;
 

--- a/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/misc/RestModuleTest.java
+++ b/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/misc/RestModuleTest.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.compat11.test.misc;
 
 import com.fasterxml.jackson.compat11.jaxrs.HelloResource;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.guicedee.guicedinjection.GuiceContext;
 import com.guicedee.guicedservlets.rest.RESTContext;
 import com.guicedee.guicedservlets.undertow.GuicedUndertow;
@@ -40,6 +41,9 @@ public class RestModuleTest
 
 		RESTContext.getProviders()
 		           .add(JacksonJaxbJsonProvider.class.getCanonicalName());
+		RESTContext.getProviders()
+		           .add(JacksonJsonProvider.class.getCanonicalName());
+
 		RESTContext.getPathServices().add(HelloResource.class.getCanonicalName());
 
 		Undertow undertow = GuicedUndertow.boot("0.0.0.0", 6003);

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,9 @@
 
         <jakarta.servlet.version>5.0.0</jakarta.servlet.version>
 
+        <!-- Test EE Framework-->
+        <guicedee.version>0.0.0_0-SNAPSHOT</guicedee.version>
+
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.12.0-rc2-SNAPSHOT</version>
+        <version>2.12.0-rc2</version>
     </parent>
     <groupId>com.fasterxml.jackson.util</groupId>
     <artifactId>jackson-jdk11-compat-test</artifactId>
     <name>Jackson-JDK11-compat-test</name>
-    <version>2.12.0-rc2-SNAPSHOT</version>
+    <version>2.12.0-rc2</version>
     <!-- @GedMarc 20190529 - JLink multi module for compatibility building- -->
     <!-- Moditect is to build foward-proof jdk8 jars-->
     <packaging>pom</packaging>


### PR DESCRIPTION
This PR puts the test libraries into the final 2.12rc2 location - 

* All tests succeed, 
* JLink builds successfully

* Restored JAXRS test on undertow for parameter reading and decoding using the decoders provided in jakarta namespace