### PR TITLE
Add jdk11 compat tests for Blackbird cross-classloader access

### DIFF
--- a/jdk11-tests/pom.xml
+++ b/jdk11-tests/pom.xml
@@ -16,6 +16,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-blackbird</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/blackbird/BlackbirdCompatTest.java
+++ b/jdk11-tests/src/test/java/com/fasterxml/jackson/compat11/test/blackbird/BlackbirdCompatTest.java
@@ -1,0 +1,77 @@
+package com.fasterxml.jackson.compat11.test.blackbird;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BlackbirdCompatTest {
+
+    private final String resourceName =
+            (BlackbirdCompatTest.class.getName() + "$Data")
+                .replace('.', '/').concat(".class");
+
+    @Test
+    public void loadInChildClassloader() throws Exception {
+        TestLoader loader = new TestLoader(getClass().getClassLoader());
+        Class<?> clazz = Class.forName(Data.class.getName(), true, loader);
+        ObjectMapper mapper = new ObjectMapper().registerModule(new BlackbirdModule());
+        Constructor<?> constructor = clazz.getConstructor(int.class);
+        Object data = constructor.newInstance(42);
+        assertEquals("{\"field\":42}", mapper.writeValueAsString(data));
+    }
+
+    public static class Data {
+        private int field;
+
+        public Data(int field) {
+            this.field = field;
+        }
+
+        public int getField() {
+            return field;
+        }
+
+        public void setField(int field) {
+            this.field = field;
+        }
+    }
+
+    public class TestLoader extends ClassLoader {
+        public TestLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                try {
+                    Class<?> clazz;
+                    if (Data.class.getName().equals(name)) {
+                        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                        InputStream in = getResource(resourceName).openStream();
+                        int i;
+                        while ((i = in.read()) != -1) {
+                            baos.write(i);
+                        }
+                        byte[] bytes = baos.toByteArray();
+                        clazz = defineClass(name, bytes, 0, bytes.length);
+                    } else {
+                        clazz = super.loadClass(name, resolve);
+                    }
+                    if (resolve) {
+                        resolveClass(clazz);
+                    }
+                    return clazz;
+                } catch (Exception e) {
+                    throw new ClassNotFoundException("Unable to load class", e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This test fails until the issue is fixed in Blackbird.
https://github.com/FasterXML/jackson-modules-base/issues/138
https://github.com/FasterXML/jackson-modules-base/pull/162

Note: I am currently not able to complete a Maven build of this project, even before changing anything I end up with:

```
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ jdk11-tests ---
[INFO] Toolchain in maven-compiler-plugin: JDK[/usr/lib/jvm/java-11]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Jackson-JDK11-compat-test 2.12.0-rc2:
[INFO] 
[INFO] Jackson-JDK11-compat-test .......................... SUCCESS [  1.096 s]
[INFO] jdk11-tests ........................................ FAILURE [  0.336 s]
[INFO] jackson-jlink ...................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project jdk11-tests: Execution default-compile of goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile failed: Unsupported major.minor version 61.0 -> [Help 1]
```

Are you able to build?